### PR TITLE
fix: EC-04 add filter by price functionality

### DIFF
--- a/src/components/Filter/RatingFilter/Rating/index.jsx
+++ b/src/components/Filter/RatingFilter/Rating/index.jsx
@@ -25,6 +25,6 @@ function Rating ( {stars} ) {
 }
 
 Rating.propTypes = {
-    stars: PropTypes.number.isRequired
+    stars: PropTypes.string.isRequired
 }
 export { Rating }

--- a/src/components/ResultInfoBar/SortFilter/index.jsx
+++ b/src/components/ResultInfoBar/SortFilter/index.jsx
@@ -1,9 +1,18 @@
 import './SortFilter.css'
+import { useContext } from 'react';
+import { SearchContext } from '../../../contexts/SearchContext';
 
 function SortFilter () {
+    const {
+        setOrder,
+    } = useContext(SearchContext);
+    const handleSetOrderChange = (event) => {
+        setOrder(event.target.value);
+    }
+
     return (
         <div className='SortFilterContainer'>
-            <select name="order" id="order">
+            <select name="order" id="order" onChange={handleSetOrderChange} > 
                 <option value="Name">Name</option>
                 <option value="Price_Low">Price: Low to High</option>
                 <option value="Price_High">Price: High to Low</option>

--- a/src/contexts/SearchContext/index.jsx
+++ b/src/contexts/SearchContext/index.jsx
@@ -12,6 +12,7 @@ function SearchProvider({ children }) {
   const [titleProduct, setTitleProduct] = useState("");
   const [priceProduct, setPriceProduct] = useState("");
   const [descriptionProduct, setDescriptionProduct] = useState("");
+  const [order, setOrder] = useState("");
 
   const getData = async () => {
     const response = await fetch("https://fakestoreapi.com/products");
@@ -32,11 +33,25 @@ function SearchProvider({ children }) {
     fetchData();
   }, []);
 
+
   const searchedProducts = products.filter((product) => {
     const productName = product.title.toLowerCase();
     const searchText = searchValue.toLowerCase();
     return productName.includes(searchText);
+  }).sort((a, b) => {
+    if (order === "Name") {
+      return a.title.localeCompare(b.title);
+    }
+    if (order === "Price_Low") {
+      return a.price - b.price;
+    }
+    if (order === "Price_High") {
+      return b.price - a.price;
+    }
   });
+
+
+
 
   return (
     <SearchContext.Provider
@@ -54,7 +69,9 @@ function SearchProvider({ children }) {
         priceProduct,
         setPriceProduct,
         descriptionProduct,
-        setDescriptionProduct
+        setDescriptionProduct,
+        order,
+        setOrder,
       }}
     >
       {children}


### PR DESCRIPTION
#### 🤔 Why?

- Add the functionality of the filter and sort by price

#### 🛠 What I changed:

- Add `order` Hook to keep a track on the changes of the order of the filter
- Add sort in `searchedProducts`  to get a ordered list according the `order`


#### 🚦 Functional Testing Results:
**Order by name**
![image](https://github.com/hayleencc/e-commerce-exercise/assets/66764846/48ceb79f-c6f4-4ee6-bbd4-fcb0de53223f)



**Order by lower price**
![image](https://github.com/hayleencc/e-commerce-exercise/assets/66764846/d2540ba5-5665-4b98-8721-d4b0ed63dc1c)


**Order by higher price**
![image](https://github.com/hayleencc/e-commerce-exercise/assets/66764846/3428664f-e1c6-43ea-a7ac-2039433072a7)
