### PR TITLE
fix: add functionality of filters by rate

### DIFF
--- a/src/components/Filter/RatingFilter/RatingFilter.css
+++ b/src/components/Filter/RatingFilter/RatingFilter.css
@@ -6,3 +6,7 @@
 .RatingsContainer {
     margin: 10px 25px;
 }
+
+.RatingsContainer .RatingValue:not(.selected) {
+    opacity: 0.6; 
+  }

--- a/src/components/Filter/RatingFilter/index.jsx
+++ b/src/components/Filter/RatingFilter/index.jsx
@@ -7,8 +7,10 @@ import PropTypes from 'prop-types'
 
 
 function RatingValue({ value, onClick }) {
+    const { selectedRate } = useContext(SearchContext);
+  
     return (
-      <div className='RatingValue' onClick={() => onClick(value)}>
+      <div className={`RatingValue ${selectedRate === value ? 'selected' : ''}`} onClick={() => onClick(value)}>
         <Rating stars={value} />
       </div>
     );

--- a/src/components/Filter/RatingFilter/index.jsx
+++ b/src/components/Filter/RatingFilter/index.jsx
@@ -22,17 +22,14 @@ RatingValue.propsTypes = {
   
 
 function RatingFilter ({ ratings }) {
-    const {setSelectedRate} = useContext(SearchContext);
+    const { setSelectedRate} = useContext(SearchContext);
 
-    const handleRatingChange = (rate) => {
-        setSelectedRate(rate);
-    }
     return (
         <div className='RatingFilterContainer'>
             <h2>Rates:</h2>
             <div className='RatingsContainer'>
                 {ratings.map((rating) => (
-                    <RatingValue key={rating} value={rating} onClick={handleRatingChange} />
+                    <RatingValue key={rating} value={rating} onClick={()=>setSelectedRate(rating)} />
                 ))}
             </div>
         </div>

--- a/src/components/Filter/RatingFilter/index.jsx
+++ b/src/components/Filter/RatingFilter/index.jsx
@@ -1,18 +1,48 @@
 import { Rating } from './Rating'
 import './RatingFilter.css'
+import { useContext } from 'react';
+import { SearchContext } from '../../../contexts/SearchContext';
+import PropTypes from 'prop-types'
 
-function RatingFilter () {
+
+
+function RatingValue({ value, onClick }) {
+    return (
+      <div className='RatingValue' onClick={() => onClick(value)}>
+        <Rating stars={value} />
+      </div>
+    );
+  }
+
+RatingValue.propsTypes = {
+    value: PropTypes.number.isRequired,
+    onClick: PropTypes.func.isRequired
+}
+
+  
+
+function RatingFilter ({ ratings }) {
+    const {setSelectedRate} = useContext(SearchContext);
+
+    const handleRatingChange = (rate) => {
+        setSelectedRate(rate);
+    }
     return (
         <div className='RatingFilterContainer'>
             <h2>Rates:</h2>
             <div className='RatingsContainer'>
-                <Rating stars={4} />
-                <Rating stars={3} />
-                <Rating stars={2} />
-                <Rating stars={1} />
+                {ratings.map((rating) => (
+                    <RatingValue key={rating} value={rating} onClick={handleRatingChange} />
+                ))}
             </div>
         </div>
     )
 }
+
+
+RatingFilter.propsTypes = {
+    ratings: PropTypes.array.isRequired,
+}
+
 
 export { RatingFilter }

--- a/src/components/Filter/index.jsx
+++ b/src/components/Filter/index.jsx
@@ -7,6 +7,7 @@ import './Filter.css'
 
 function Filter () {
     const {modifyingCategories} = useContext(SearchContext);
+    const ratings = [4, 3, 2, 1];
     return (
         <div className='FilterContainer'>
             <TypeFilter
@@ -19,7 +20,7 @@ function Filter () {
                 ]}
                 onCategoryChange={modifyingCategories}
             />
-            <RatingFilter />
+            <RatingFilter ratings={ratings} />
         </div>
     )
 }

--- a/src/components/Modal/index.jsx
+++ b/src/components/Modal/index.jsx
@@ -10,7 +10,8 @@ function Modal () {
         imageProduct,
         titleProduct,
         priceProduct,
-        descriptionProduct
+        descriptionProduct,
+        rateProduct
     } = useContext(SearchContext);
 
     const setCloseModal = () => {
@@ -29,7 +30,7 @@ function Modal () {
                         <h3>{titleProduct}</h3>
                         <h3>${priceProduct}</h3>
                     </div>
-                    <Rating stars={3}/>
+                    <Rating stars={rateProduct}/>
                     <h6>{descriptionProduct}</h6>
                 </div>
             </div>

--- a/src/components/ResultTable/Card/Detail/index.jsx
+++ b/src/components/ResultTable/Card/Detail/index.jsx
@@ -3,11 +3,11 @@ import { CartButton } from "../../../Button"
 import PropTypes from 'prop-types'
 import './Detail.css'
 
-function Detail({ title, price }) {
+function Detail({ title, price, rating }) {
     return (
         <div className="DetailsCardContainer">
             <h3>{title}</h3>
-            <Rating stars={3} />
+            {rating && <Rating stars={rating} />}
             <h3>${price}</h3>
             <CartButton />
         </div>
@@ -16,7 +16,8 @@ function Detail({ title, price }) {
 
 Detail.propTypes = {
     title: PropTypes.string.isRequired,
-    price: PropTypes.string.isRequired
+    price: PropTypes.number.isRequired,
+    rating: PropTypes.number
 }
 
 export { Detail }

--- a/src/components/ResultTable/Card/index.jsx
+++ b/src/components/ResultTable/Card/index.jsx
@@ -4,13 +4,14 @@ import { SearchContext } from '../../../contexts/SearchContext';
 import './Card.css'
 import PropTypes from 'prop-types'
 
-function Card({ image, title, price, description }) {
+function Card({ image, title, price, description, rating }) {
     const {
         setIsOpen,
         setImageProduct,
         setTitleProduct,
         setPriceProduct,
         setDescriptionProduct,
+        setRateProduct
     } = useContext(SearchContext);
 
     const openModal = () => {
@@ -19,6 +20,7 @@ function Card({ image, title, price, description }) {
         setTitleProduct(title)
         setPriceProduct(price)
         setDescriptionProduct(description)
+        setRateProduct(rating)
     }
 
     return (
@@ -29,6 +31,7 @@ function Card({ image, title, price, description }) {
             <Detail
                 title={title}
                 price={price}
+                rating={rating}
             />
         </div>
     )
@@ -38,7 +41,8 @@ Card.propTypes = {
     image: PropTypes.string.isRequired,
     title: PropTypes.string.isRequired,
     price: PropTypes.string.isRequired,
-    description: PropTypes.string.isRequired
+    description: PropTypes.string.isRequired,
+    rating: PropTypes.number.isRequired
 }
 
 export { Card }

--- a/src/components/ResultTable/index.jsx
+++ b/src/components/ResultTable/index.jsx
@@ -24,6 +24,7 @@ function ResultTable () {
                             title = {product.title}
                             price = {product.price}
                             description = {product.description}
+                            rating = {Math.round(product.rating.rate)}
                         />
                     )
                 }

--- a/src/contexts/SearchContext/index.jsx
+++ b/src/contexts/SearchContext/index.jsx
@@ -44,9 +44,9 @@ function SearchProvider({ children }) {
   })
   .sort((a, b) => filterProductsByPriceOrName(a, b, order)).filter((product) => {
     if (categories.length === 0) {
-      return true;
+      return product.rating.rate >= selectedRate;
     }
-    return categories.includes(product.category);
+    return categories.includes(product.category) && product.rating.rate >= selectedRate;
   });
 
 

--- a/src/contexts/SearchContext/index.jsx
+++ b/src/contexts/SearchContext/index.jsx
@@ -14,6 +14,8 @@ function SearchProvider({ children }) {
   const [descriptionProduct, setDescriptionProduct] = useState("");
   const [order, setOrder] = useState("Name");
   const [categories, setCategories] = useState([]);
+  const [selectedRate, setSelectedRate] = useState(1);
+  const [rateProduct, setRateProduct] = useState(1);
 
   const getData = async () => {
     const response = await fetch("https://fakestoreapi.com/products");
@@ -99,7 +101,11 @@ const modifyingCategories = (id) => {
         setOrder,
         categories,
         setCategories,
-        modifyingCategories
+        modifyingCategories,
+        selectedRate,
+        setSelectedRate,
+        rateProduct,
+        setRateProduct,
       }}
     >
       {children}


### PR DESCRIPTION
#### 🤔 Why?

- Currently the filter by rate was not working, also, the rate values were fixed values instead to use the provided by the API

#### 🛠 What I changed:

- Use the rate values provided by the API instead fixed values.
- Add the filter by rate to the searched products list.


#### 🚦 Functional Testing Results:

If the rate "4" is selected we will obtain the following results:
![image](https://github.com/hayleencc/e-commerce-exercise/assets/66764846/f98c992c-6eca-4070-8e31-40b2be64d374)


The rate value was fixed in the card of the product too:
![image](https://github.com/hayleencc/e-commerce-exercise/assets/66764846/8cece678-e48e-495d-94bf-1c770d24cf26)

